### PR TITLE
fix: マイナス値で更新できてしまう問題の解決を行なった

### DIFF
--- a/server/api/handler/request/stock.go
+++ b/server/api/handler/request/stock.go
@@ -24,8 +24,8 @@ type CreateBulkStockRequest struct {
 type UpdateStockRequest struct {
 	StockID  string `param:"id" validate:"required,numeric,gt=0" example:"1" swaggerignore:"true"`
 	Name     string `json:"name" validate:"required,min=1,max=255" example:"LOUIS VUITTON M41524 ブラウン モノグラム ハンドバッグ"`
-	Quantity int    `json:"quantity" validate:"required,numeric" example:"1"`
-	Price    int    `json:"price" validate:"required,numeric" example:"100000"`
+	Quantity int    `json:"quantity" validate:"required,numeric,gte=0" example:"1" minimum:"0"`
+	Price    int    `json:"price" validate:"required,numeric,gte=0" example:"100000" minimum:"0"`
 	StoreID  string `json:"store_id" validate:"required,uuid4" example:"00000000-0000-0000-0000-000000000000"`
 	UserID   string `json:"user_id" validate:"required,uuid4" example:"00000000-0000-0000-0000-000000000000"`
 }


### PR DESCRIPTION
## Issue の URL

https://github.com/buysell-technologies/summer-internship-2025-0909-b/issues/11

## やったこと

在庫の修正においてマイナス値が指定できてしまう状況を確認し、それに対してリクエストの部分で最小値を設定することにより防止した。

## やらないこと

なし

## 動作確認観点

<img width="1660" height="189" alt="image" src="https://github.com/user-attachments/assets/d330dff4-3830-4365-8f52-99f2fbca7bb1" />

- [x] セルフレビューを十分行い、Reviews を選択した

# AIの活用
ソースコードを読み、問題の対象となっていると思った関数部分について、以下のプロンプトで解決方法を聞いた。
プロンプト
```
この関数においてPUTでの更新処理を行なっていると思いますが、マイナス値で更新できないようにしてください
```