### PR TITLE
顧客管理画面がホワイトアウトする不具合を修正する #8

### DIFF
--- a/frontend/src/pages/customer/CustomersPage.tsx
+++ b/frontend/src/pages/customer/CustomersPage.tsx
@@ -31,15 +31,23 @@ const CustomersPage = () => {
   const [page, setPage] = useState(0);
 
   const [rowsPerPage, setRowsPerPage] = useState<number>(() => {
-    const stored = localStorage.getItem(CUSTOMER_PAGE_SETTINGS_STORAGE_KEY)!;
-    const parsed = JSON.parse(stored) as CustomerPageSettings;
-    if (
-      typeof parsed.rowsPerPage === 'number' &&
-      VALID_PAGE_SIZES.includes(parsed.rowsPerPage as ValidPageSize)
-    ) {
-      return parsed.rowsPerPage;
+    try {
+      const stored = localStorage.getItem(CUSTOMER_PAGE_SETTINGS_STORAGE_KEY);
+      if (!stored) {
+        return DEFAULT_SETTINGS.rowsPerPage;
+      }
+      const parsed = JSON.parse(stored) as CustomerPageSettings;
+      if (
+        typeof parsed.rowsPerPage === 'number' &&
+        VALID_PAGE_SIZES.includes(parsed.rowsPerPage as ValidPageSize)
+      ) {
+        return parsed.rowsPerPage;
+      }
+      return DEFAULT_SETTINGS.rowsPerPage;
+    } catch (error) {
+      console.error('Failed to parse customer page settings:', error);
+      return DEFAULT_SETTINGS.rowsPerPage;
     }
-    return DEFAULT_SETTINGS.rowsPerPage;
   });
 
   const { data, isLoading, error, refetch } = useGetCustomers({
@@ -48,14 +56,18 @@ const CustomersPage = () => {
   });
 
   useEffect(() => {
-    const settings: CustomerPageSettings = {
-      rowsPerPage,
-      lastUpdated: new Date().toISOString(),
-    };
-    localStorage.setItem(
-      CUSTOMER_PAGE_SETTINGS_STORAGE_KEY,
-      JSON.stringify(settings),
-    );
+    try {
+      const settings: CustomerPageSettings = {
+        rowsPerPage,
+        lastUpdated: new Date().toISOString(),
+      };
+      localStorage.setItem(
+        CUSTOMER_PAGE_SETTINGS_STORAGE_KEY,
+        JSON.stringify(settings),
+      );
+    } catch (error) {
+      console.error('Failed to save customer page settings:', error);
+    }
   }, [rowsPerPage]);
 
   const handleChangePage = (_event: unknown, newPage: number) => {


### PR DESCRIPTION


## Issue の URL
https://github.com/buysell-technologies/summer-internship-2025-0909-b/issues/8


## やったこと
LocalStorageに保存されているCUSTOMER_PAGE_SETTINGS_STORAGE_KEYが不正またはない場合にクラッシュしないようにデフォルト値を追加した。

## 動作確認観点

![Uploading スクリーンショット 2025-09-09 152609.png…]()


- [ ] セルフレビューを十分行い、Reviews を選択した
