### PR TITLE
SQLが大量に発行されている #13

### DIFF
--- a/server/api/repository/user.go
+++ b/server/api/repository/user.go
@@ -11,6 +11,7 @@ func (r *repository) GetUsers(ctx context.Context, tenantID string, limit, offse
 	users := []*model.User{}
 
 	if err := r.db.Unscoped().
+		Preload("Stocks").
 		Joins("LEFT JOIN stores AS s ON users.store_id = s.id").
 		Where("s.tenant_id = ?", tenantID).
 		Limit(limit).
@@ -18,13 +19,6 @@ func (r *repository) GetUsers(ctx context.Context, tenantID string, limit, offse
 		Find(&users).
 		Error; err != nil {
 		return nil, err
-	}
-
-	for i, user := range users {
-		stocks := []*model.Stock{}
-		if err := r.db.Where("user_id = ?", user.ID).Find(&stocks).Error; err == nil {
-			users[i].Stocks = stocks
-		}
 	}
 
 	return users, nil


### PR DESCRIPTION
<!-- 必要に応じて変更してください -->

## Issue の URL

https://github.com/buysell-technologies/summer-internship-2025-0909-b/issues/13

## やったこと
```
	if err := r.db.Unscoped().
		Preload("Stocks").
		Joins("LEFT JOIN stores AS s ON users.store_id = s.id").
		Where("s.tenant_id = ?", tenantID).
		Limit(limit).
		Offset(offset).
		Find(&users).
		Error; err != nil {
		return nil, err
	}
```
Without Preload:
-- 1回目: ユーザー取得
SELECT * FROM users WHERE ...

-- 2〜N回目: 各ユーザーごとに個別実行
SELECT * FROM stocks WHERE user_id = 'user1'
SELECT * FROM stocks WHERE user_id = 'user2'
SELECT * FROM stocks WHERE user_id = 'user3'
...

With Preload（効率的）:
-- 1回目: ユーザー取得
SELECT * FROM users WHERE ...

-- 2回目: 関連stocks一括取得
SELECT * FROM stocks WHERE user_id IN ('user1', 'user2', 'user3', ...)


<!-- この PR でやらないことを書いてください -->

## 動作確認観点
![Uploading スクリーンショット 2025-09-09 160753.png…]()

- [ ] セルフレビューを十分行い、Reviews を選択した
