### PR TITLE
Feat 11 csv output

### DIFF
--- a/frontend/src/pages/stock/StocksPage.tsx
+++ b/frontend/src/pages/stock/StocksPage.tsx
@@ -26,7 +26,10 @@ const StocksPage = () => {
     const stocks = data || [];
     const formatPrice = (price?: number) => {
       if (price === undefined || price === null) return '';
-      return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(price);
+      return new Intl.NumberFormat('ja-JP', {
+        style: 'currency',
+        currency: 'JPY',
+      }).format(price);
     };
     const formatDate = (iso?: string) => {
       if (!iso) return '';


### PR DESCRIPTION
## Issue の URL

https://github.com/buysell-technologies/summer-internship-2025-0909-b/issues/4

## やったこと

在庫管理画面に「CSV出力」ボタンを追加
配置: 検索・フィルタUIの行の右側に配置
CSVダウンロード機能の実装
クリックで exportStocksCsv() を実行し、現在ページの在庫データをCSV出力
CSV生成は convertCSVFromArray（frontend/src/utils/convertCSVFromArray.ts）を利用
文字コード: UTF-8 + BOM（Googleスプレッドシートでの文字化け防止）
ファイル名: stocks_YYYYMMDD_HHMMSS.csv
出力内容の整形
ヘッダー: 日本語カラム名（ID, 商品名, 価格, 在庫数, 作成日時, 更新日時）
価格: 日本円表記（例: ¥1,234）
日時: YYYY/MM/DD HH:MM 形式に整形
ダウンロード中はボタンをdisabled化し、ラベルを「出力中…」に変更
エラー時にアラート表示（対象データなし・出力失敗時）
レスポンシブ対応（MUIのsxで実装）

## やらないこと

なし

## 動作確認観点

<img width="667" height="211" alt="image" src="https://github.com/user-attachments/assets/1c33cfd1-e8d5-4fba-a8fd-60bdc6f984a7" />
<img width="1393" height="749" alt="image" src="https://github.com/user-attachments/assets/c29fcc6a-bce9-44da-88e7-1b579cb1848a" />


- [x] セルフレビューを十分行い、Reviews を選択した
